### PR TITLE
return a 404 (rather than 500) on missing locales

### DIFF
--- a/app/controllers/mirador_rails/locales_controller.rb
+++ b/app/controllers/mirador_rails/locales_controller.rb
@@ -5,6 +5,8 @@ module MiradorRails
       language = params.fetch(:locale) { I18n.default_locale.to_s }
       locale = MiradorRails::Locale.new(language)
       render json: locale.file_source
+    rescue MiradorRails::Exceptions::LocaleNotFound
+      raise ActionController::RoutingError.new('Not Found')
     end
   end
 end


### PR DESCRIPTION
This PR fixes #6 by catching `LocaleNotFound` exceptions and rendering a 404.